### PR TITLE
Package.json updated with binaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,17 @@
   "description": "Quasar Framework CLI",
   "preferGlobal": true,
   "bin": {
-    "quasar": "./bin/quasar"
+    "quasar": "./bin/quasar",
+    "quasar-build": "./bin/quasar-build",
+    "quasar-clean": "./bin/quasar-clean",
+    "quasar-dev": "./bin/quasar-dev",
+    "quasar-init": "./bin/quasar-init",
+    "quasar-lint": "./bin/quasar-lint",
+    "quasar-list": "./bin/quasar-list",
+    "quasar-new": "./bin/quasar-new",
+    "quasar-serve": "./bin/quasar-serve",
+    "quasar-test": "./bin/quasar-test",
+    "quasar-wrap": "./bin/quasar-wrap"
   },
   "files": [
     "bin",


### PR DESCRIPTION
Hi! First of all, many thanks for the great work on Quasar. It's really awesome!

I'd like to propose a change on package.json. When I install `quasar-cli` through [Yarn](https://yarnpkg.com/) (the new and fast Node.js package manager) I can't get the quasar commands to be installed by default.

So... I made a little change on package.json telling where the bin's are, and now the everything is running pretty smoothly when I install it through Yarn.

Hope it helps the people that are struggling to get it up and running on the new package manager.

Thanks in advance!